### PR TITLE
use sync_subscribe instead of subscribe when subscibing to mqtt

### DIFF
--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -80,7 +80,7 @@ defmodule Carrier.Messaging.Connection do
     # See
     # http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718101
     # for more.
-    :emqttc.subscribe(conn, topic, :qos1)
+    :emqttc.sync_subscribe(conn, topic, :qos1)
   end
 
   def unsubscribe(conn, topic) do


### PR DESCRIPTION
When subscribing to transient topics it is possible to publish messages before the subscription has taken place. By using sync_subscribe we should be guaranteed to have the subscription in place before we start sending messages.
