### PR TITLE
Update adz dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Carrier.Mixfile do
   defp deps do
     [{:enacl, github: "jlouis/enacl", tag: "0.15.0"},
      {:emqttc, github: "operable/emqttc", tag: "cog-0.2"},
-     {:adz, git: "git@github.com:operable/adz", tag: "0.2"},
+     {:adz, github: "operable/adz", tag: "0.2"},
      {:uuid, "~> 1.1.3"},
      {:poison, "~> 1.5.2"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"adz": {:git, "git@github.com:operable/adz", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
+%{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},
   "enacl": {:git, "https://github.com/jlouis/enacl.git", "03f93c4f7d0cb56b5a86b445cb004a3a8de2278b", [tag: "0.15.0"]},
   "gen_logger": {:git, "git://github.com/emqtt/gen_logger.git", "eced518f1dea167bebd576bb8b1cccb764a45739", [branch: "master"]},


### PR DESCRIPTION
:information_desk_person: The `operable/adz` dependency is now open source, so updated the URL to reflect this.