### PR TITLE
Enable SSL connections if configured

### DIFF
--- a/lib/carrier/messaging/connection.ex
+++ b/lib/carrier/messaging/connection.ex
@@ -119,7 +119,24 @@ defmodule Carrier.Messaging.Connection do
              false ->
                host
            end
-    [{:host, host}, {:port, port}, {:logger, {:lager, log_level}} | opts]
+    updated = [{:host, host}, {:port, port}, {:logger, {:lager, log_level}} | opts]
+    configure_ssl(updated, connect_opts)
+  end
+
+  # Enable SSL connections when SSL config is provided
+  defp configure_ssl(opts, connect_opts) do
+    if Keyword.get(connect_opts, :ssl, false) do
+      cacertfile = Keyword.get(connect_opts, :cacerts, nil)
+      if is_binary(cacertfile) do
+        # Convert to char list since emqttc is expecting Erlang strings
+        cacertfile = String.to_char_list(cacertfile)
+        [ssl: [verify: :verify_peer, crl_check: true, cacertfile: cacertfile]] ++ opts
+      else
+        [:ssl | opts]
+      end
+    else
+      opts
+    end
   end
 
 end


### PR DESCRIPTION
Added support for MQTTS (MQTT over SSL) via two new configuration keys.

### Enabling SSL support
config.exs: `config :carrier, Carrier.Messaging.Connection, ssl: true`
emqttc: `:ssl`
### Enabling SSL certification verification
config.exs: `config :carrier, Carrier.Messaging.Connection, cacerts: "path/to/cacerts"`
emqttc: `[ssl: verify: :verify_peer, crl_check: true, cacertfile: 'path/to/cacerts']`

Carrier handles transforming config.exs entries into the corresponding emqttc connect options.

Fixes client side of Cog [#106](https://github.com/operable/cog/issues/106)