### PR TITLE
Remove enacl dependency.

### DIFF
--- a/lib/carrier/credential_signature.ex
+++ b/lib/carrier/credential_signature.ex
@@ -1,7 +1,6 @@
 defimpl Carrier.Signature, for: Carrier.Credentials do
 
   alias Carrier.Credentials
-  alias Carrier.Util
 
   @doc "Signs a JSON object using `Carrier.Credentials`"
   @spec sign(Credentials.t(), Map.t()) :: Map.t() | no_return()
@@ -11,34 +10,13 @@ defimpl Carrier.Signature, for: Carrier.Credentials do
 
   @doc "Verify JSON object signature"
   @spec verify(Map.t(), binary()) :: boolean() | no_return()
-  def verify(%Credentials{}=creds, %{"data" => obj, "signature" => sig}) when is_map(obj) do
-    sig = Util.hex_string_to_binary(sig)
-    text = mangle!(obj)
-    case :enacl.sign_verify_detached(sig, text, creds.public) do
-      {:ok, ^text} ->
-        true
-      _ ->
-        false
-    end
-  end
-
-  @spec mangle!(Map.t()) :: binary() | no_return()
-  defp mangle!(obj) do
-    # Message signatures can be thought of as a kind of checksum.
-    # To eliminate any reliance on unspecified behaviors such as
-    # hashtable ordering we sign a mangled version of the JSON text.
-    Poison.encode!(obj)
-    |> String.codepoints
-    |> Enum.filter(fn(cp) -> String.match?(cp, ~r/\s/) == false end)
-    |> Enum.sort
-    |> List.to_string
+  def verify(_creds, _obj) do
+    true
   end
 
   @spec sign(Map.t(), binary(), String.t()) :: Map.t() | no_return()
-  defp sign(obj, key, id) when is_map(obj) do
-    text = mangle!(obj)
-    sig = :enacl.sign_detached(text, key)
-    sig = Util.binary_to_hex_string(sig)
+  defp sign(obj, _key, id) when is_map(obj) do
+    sig = "deprecated"
     %{"data" => obj, "signature" => sig, "id" => id}
   end
 

--- a/lib/carrier/credentials.ex
+++ b/lib/carrier/credentials.ex
@@ -13,8 +13,7 @@ defmodule Carrier.Credentials do
   @doc "Generates a new private/public keypair"
   @spec generate() :: %__MODULE__{}
   def generate() do
-    keys = :enacl.sign_keypair()
-    %__MODULE__{id: UUID.uuid4(), private: keys.secret, public: keys.public}
+    %__MODULE__{id: UUID.uuid4(), private: "deprecated", public: "deprecated"}
   end
 
   @doc "Adds a tag to credentials"

--- a/mix.exs
+++ b/mix.exs
@@ -18,8 +18,7 @@ defmodule Carrier.Mixfile do
   end
 
   defp deps do
-    [{:enacl, github: "jlouis/enacl", tag: "0.15.0"},
-     {:emqttc, github: "operable/emqttc", tag: "cog-0.2"},
+    [{:emqttc, github: "operable/emqttc", tag: "cog-0.2"},
      {:adz, github: "operable/adz", tag: "0.2"},
      {:uuid, "~> 1.1.3"},
      {:poison, "~> 1.5.2"}]

--- a/test/carrier/signature_test.exs
+++ b/test/carrier/signature_test.exs
@@ -31,11 +31,4 @@ defmodule Carrier.SignatureTest do
     assert Signature.verify(context.creds, signed)
   end
 
-  test "fail verifying signed JSON object with wrong key", context do
-    obj = %{first_name: "Bob", last_name: "Bobbington"}
-    signed = Signature.sign(context.creds, obj)
-    verify_signature_envelope(signed, obj, context.creds)
-    refute Signature.verify(context.other_creds, signed)
-  end
-
 end


### PR DESCRIPTION
Fair warning, this PR is gross. It removes the enacl dependency (and the requirements for dirty-schedulers and SMP support along with it) by the simple expedient of stubbing out places where signatures were used.

This is just a mile marker on the road toward removing the rest of the signature related credential management as we change the way that relays interact with Cog, centralize management, and so on.